### PR TITLE
Redis and minio enhancement

### DIFF
--- a/charts/dev-backends/Chart.yaml
+++ b/charts/dev-backends/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: dev-backend
-version:  0.0.1
+version:  0.0.2
 appVersion: latest

--- a/charts/dev-backends/templates/minio.yaml
+++ b/charts/dev-backends/templates/minio.yaml
@@ -1,13 +1,40 @@
 {{ if .Values.minio.enabled }}
+{{- if .Values.minio.ingress.enabled }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "dev-backends.minio.fullname" . }}
+  name: {{ template "dev-backends.minio.fullname" . }}-api
   namespace: {{ include  "dev-backends.namespace" . }}
 spec:
   rules:
-  - host: "{{ .Values.minio.hostname }}"
+  - host: "{{ .Values.minio.ingress.hostname }}"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .Values.minio.serviceNameOverride | default (include "dev-backends.minio.fullname" . | trunc 52 | trimSuffix "-") }}
+            port:
+              number: 9000
+  {{ if .Values.minio.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - "{{ .Values.minio.ingress.hostname }}"
+    secretName: "{{ .Values.minio.ingress.tls.secretName }}"
+  {{- end }}
+{{- end }}
+{{- if .Values.minio.consoleIngress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "dev-backends.minio.fullname" . }}-console
+  namespace: {{ include  "dev-backends.namespace" . }}
+spec:
+  rules:
+  - host: "{{ .Values.minio.consoleIngress.hostname }}"
     http:
       paths:
       - path: /
@@ -17,12 +44,13 @@ spec:
             name: {{ .Values.minio.serviceNameOverride | default (include "dev-backends.minio.fullname" . | trunc 52 | trimSuffix "-") }}
             port:
               number: 9001
-  {{ if .Values.minio.tls.enabled }}
+  {{ if .Values.minio.consoleIngress.tls.enabled }}
   tls:
   - hosts:
-    - "{{ .Values.minio.hostname }}"
-    secretName: "{{ .Values.minio.tls.secretName }}"
+    - "{{ .Values.minio.consoleIngress.hostname }}"
+    secretName: "{{ .Values.minio.consoleIngress.tls.secretName }}"
   {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -84,6 +112,8 @@ spec:
               secretKeyRef:
                 key: username
                 name: {{ .Values.minio.serviceNameOverride | default (include "dev-backends.minio.fullname" . | trunc 52 | trimSuffix "-") }}
+          - name: MINIO_API_CORS_ALLOW_ORIGIN
+            value: "*"
         image: {{ .Values.minio.image }}
         imagePullPolicy: IfNotPresent
         ports:

--- a/charts/dev-backends/templates/minio.yaml
+++ b/charts/dev-backends/templates/minio.yaml
@@ -78,12 +78,12 @@ spec:
             valueFrom:
               secretKeyRef:
                 key: password
-                name: {{ template "dev-backends.minio.fullname" . }}
+                name: {{ .Values.minio.serviceNameOverride | default (include "dev-backends.minio.fullname" . | trunc 52 | trimSuffix "-") }}
           - name: MINIO_ROOT_USER
             valueFrom:
               secretKeyRef:
                 key: username
-                name: {{ template "dev-backends.minio.fullname" . }}
+                name: {{ .Values.minio.serviceNameOverride | default (include "dev-backends.minio.fullname" . | trunc 52 | trimSuffix "-") }}
         image: {{ .Values.minio.image }}
         imagePullPolicy: IfNotPresent
         ports:

--- a/charts/dev-backends/templates/minio.yaml
+++ b/charts/dev-backends/templates/minio.yaml
@@ -139,7 +139,12 @@ spec:
               exit 0
             fi
             echo "Create bucket"
-            /usr/bin/mc mb local-server/{{ .Values.minio.bucket }} && \
+            /usr/bin/mc mb local-server/{{ .Values.minio.bucket }}
+            enable_versioning={{ .Values.minio.versioning }}
+            if [ "$enable_versioning" = "true" ]; then
+              /usr/bin/mc version enable local-server/{{ .Values.minio.bucket }}
+              echo "Versioning enabled"
+            fi
             exit 0
       restartPolicy: Never
   backoffLimit: 1

--- a/charts/dev-backends/values.yaml
+++ b/charts/dev-backends/values.yaml
@@ -33,6 +33,7 @@ minio:
   password: password
   bucket: dinum
   size: 1Gi
+  versioning: false
 
 keycloak:
   enabled: false

--- a/charts/dev-backends/values.yaml
+++ b/charts/dev-backends/values.yaml
@@ -25,10 +25,18 @@ minio:
   image: minio/minio
   name: minio
   #serviceNameOverride: minio
-  hostname: minio.127.0.0.1.nip.io
-  tls:
+  ingress:
     enabled: false
-    secretName: minio-tls
+    hostname: minio.127.0.0.1.nip.io
+    tls:
+      enabled: false
+      secretName: minio-tls
+  consoleIngress:
+    enabled: false
+    hostname: minio-console.127.0.0.1.nip.io
+    tls:
+      enabled: false
+      secretName: minio-tls
   username: dinum
   password: password
   bucket: dinum


### PR DESCRIPTION
The redis secret name was not using the override service name option and could lead to a deployment error.

The bucket versioning was not allowed on minio, a new parameter allow to activate it.
The minio ingresses have been refactored, API and console ingresses are two disctincts ingress and bot are disabled by default.