### PR TITLE
✨(cicap) add c-icap service for malware detection development

### DIFF
--- a/charts/dev-backends/Chart.yaml
+++ b/charts/dev-backends/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 type: application
 name: dev-backend
-version: 0.0.8
+version: 0.0.9
 appVersion: latest

--- a/charts/dev-backends/templates/_helpers.tpl
+++ b/charts/dev-backends/templates/_helpers.tpl
@@ -53,6 +53,15 @@ to 63 chars and it includes 10 chars of hash and a separating '-'.
 {{- end -}}
 
 {{/*
+Create cicap name and version as used by the chart label.
+Truncated at 52 chars because StatefulSet label 'controller-revision-hash' is limited
+to 63 chars and it includes 10 chars of hash and a separating '-'.
+*/}}
+{{- define "dev-backends.cicap.fullname" -}}
+{{- printf "%s-%s" (include "dev-backends.fullname" .) .Values.cicap.name | trunc 52 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 transform dictionnary of environment variables
 Usage : {{ include "dev-backends.env.transformDict" .Values.envVars }}
 

--- a/charts/dev-backends/templates/cicap-configmap.yaml
+++ b/charts/dev-backends/templates/cicap-configmap.yaml
@@ -1,0 +1,62 @@
+{{ if .Values.cicap.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "dev-backends.cicap.fullname" . }}
+  namespace: {{ include  "dev-backends.namespace" . }}
+  labels:
+    app.kubernetes.io/instance: dev-backends
+    app.kubernetes.io/name: cicap
+data:
+  c-icap.conf: |
+    PidFile /var/run/c-icap/c-icap.pid
+    Timeout 300
+    MaxKeepAliveRequests 100
+    KeepAliveTimeout 600
+    StartServers 1
+    MaxServers 4
+    MinSpareThreads 10
+    MaxSpareThreads 20
+    ThreadsPerChild 10
+    MaxRequestsPerChild 0
+    Port {{ .Values.cicap.port }}
+    ServerAdmin c-icap-admin
+    ServerName c-icap
+    TmpDir /var/tmp
+    MaxMemObject 131072
+    DebugLevel 1
+    Pipelining on
+    SupportBuggyClients off
+    ModulesDir /var/lib/clamav/lib/c_icap
+    ServicesDir /var/lib/clamav/lib/c_icap
+    TemplateDir /var/lib/clamav/share/c_icap/templates/
+    TemplateDefaultLanguage en
+    LoadMagicFile /var/lib/clamav/etc/c-icap.magic
+    RemoteProxyUsers off
+    RemoteProxyUserHeader X-Authenticated-User
+    RemoteProxyUserHeaderEncoded on
+    ServerLog /dev/stdout
+    AccessLog /dev/stdout
+    Service echo srv_echo.so
+    Include virus_scan.conf
+  virus_scan.conf: |
+    Service antivirus_module virus_scan.so
+    ServiceAlias srv_clamav virus_scan
+    ServiceAlias avscan virus_scan?allow204=on&sizelimit=off&mode=simple
+    virus_scan.ScanFileTypes TEXT DATA EXECUTABLE ARCHIVE GIF JPEG MSOFFICE
+    virus_scan.SendPercentData 5
+    virus_scan.StartSendPercentDataAfter 2M
+    virus_scan.MaxObjectSize {{ .Values.cicap.maxObjectSize }}
+    Include clamd_mod.conf
+  clamd_mod.conf: |
+    Module common clamd_mod.so
+    clamd_mod.ClamdHost 127.0.0.1
+    clamd_mod.ClamdPort 3310
+  clamd.conf: |
+    DatabaseDirectory /var/lib/clamav
+    TCPSocket 3310
+    StreamMaxLength {{ .Values.cicap.streamMaxLength }}
+    Foreground yes
+    LogFile /dev/stdout
+{{ end }}

--- a/charts/dev-backends/templates/cicap.yaml
+++ b/charts/dev-backends/templates/cicap.yaml
@@ -35,14 +35,52 @@ spec:
       labels:
         app.kubernetes.io/instance: dev-backends
         app.kubernetes.io/name: cicap
+      annotations:
+        configmap/hash: {{ include (print $.Template.BasePath "/cicap-configmap.yaml") . | sha256sum }}
     spec:
+      initContainers:
+      - name: fix-permissions
+        image: "{{ .Values.cicap.clamd.image }}"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        command:
+          - sh
+          - -c
+          - |
+            chown -R clamav:clamav /var/lib/clamav
+        volumeMounts:
+        - name: clamav-db
+          mountPath: /var/lib/clamav
       containers:
       - name: cicap
-        image: "{{ .Values.cicap.image }}"
+        image: "{{ .Values.cicap.registry }}/{{ .Values.cicap.repository }}:{{ .Values.cicap.tag }}"
         imagePullPolicy: IfNotPresent
+        command:
+          - /bin/sh
+          - -c
+          - |
+            until nc -z 127.0.0.1 3310; do
+              echo 'Clamd not responding yet, waiting...';
+              sleep 2;
+            done;
+            exec /var/lib/clamav/bin/c-icap -N -D
         ports:
         - containerPort: {{ .Values.cicap.port }}
           name: tcp-cicap
+        volumeMounts:
+        - name: config
+          mountPath: /var/lib/clamav/etc/c-icap.conf
+          subPath: c-icap.conf
+          readOnly: true
+        - name: config
+          mountPath: /var/lib/clamav/etc/virus_scan.conf
+          subPath: virus_scan.conf
+          readOnly: true
+        - name: config
+          mountPath: /var/lib/clamav/etc/clamd_mod.conf
+          subPath: clamd_mod.conf
+          readOnly: true
         resources:
           {{- toYaml .Values.cicap.resources | nindent 10 }}
         readinessProbe:
@@ -50,4 +88,30 @@ spec:
             port: tcp-cicap
           initialDelaySeconds: 30
           periodSeconds: 10
+      - name: clamd
+        image: "{{ .Values.cicap.clamd.image }}"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3310
+          name: tcp-clamd
+        volumeMounts:
+        - name: config
+          mountPath: /etc/clamav/clamd.conf
+          subPath: clamd.conf
+          readOnly: true
+        - name: clamav-db
+          mountPath: /var/lib/clamav
+        resources:
+          {{- toYaml .Values.cicap.resources | nindent 10 }}
+        readinessProbe:
+          tcpSocket:
+            port: tcp-clamd
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "dev-backends.cicap.fullname" . }}
+      - name: clamav-db
+        emptyDir: {}
 {{ end }}

--- a/charts/dev-backends/templates/cicap.yaml
+++ b/charts/dev-backends/templates/cicap.yaml
@@ -1,0 +1,53 @@
+{{ if .Values.cicap.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.cicap.serviceNameOverride | default (include "dev-backends.cicap.fullname" . | trunc 52 | trimSuffix "-") }}
+  namespace: {{ include  "dev-backends.namespace" . }}
+spec:
+  ports:
+  - name: tcp-cicap
+    port: {{ .Values.cicap.port }}
+    protocol: TCP
+    targetPort: tcp-cicap
+  selector:
+    app.kubernetes.io/instance: dev-backends
+    app.kubernetes.io/name: cicap
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "dev-backends.cicap.fullname" . }}
+  namespace: {{ include  "dev-backends.namespace" . }}
+  labels:
+    app.kubernetes.io/instance: dev-backends
+    app.kubernetes.io/name: cicap
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dev-backends
+      app.kubernetes.io/name: cicap
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: dev-backends
+        app.kubernetes.io/name: cicap
+    spec:
+      containers:
+      - name: cicap
+        image: "{{ .Values.cicap.image }}"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: {{ .Values.cicap.port }}
+          name: tcp-cicap
+        resources:
+          {{- toYaml .Values.cicap.resources | nindent 10 }}
+        readinessProbe:
+          tcpSocket:
+            port: tcp-cicap
+          initialDelaySeconds: 30
+          periodSeconds: 10
+{{ end }}

--- a/charts/dev-backends/values.yaml
+++ b/charts/dev-backends/values.yaml
@@ -110,6 +110,15 @@ cicap:
   enabled: false
   name: cicap
   #serviceNameOverride: cicap
-  image: opencloudeu/clamav-icap:latest
+  registry: registry.opencode.de
+  repository: bmi/opendesk/components/platform-development/images/clamav-icap
+  tag: "0.6.4"
+  # The clamd sidecar runs the ClamAV daemon and keeps the virus database up to date
+  clamd:
+    image: clamav/clamav:stable
   port: 1344
+  # MaxObjectSize limits the size of files scanned by the ICAP service
+  maxObjectSize: 100M
+  # StreamMaxLength limits the size of files scanned by clamd
+  streamMaxLength: 100M
   resources: {}

--- a/charts/dev-backends/values.yaml
+++ b/charts/dev-backends/values.yaml
@@ -105,3 +105,11 @@ dsproxy:
       secretName: dsproxy-tls
   localSecret:
     enabled: false
+
+cicap:
+  enabled: false
+  name: cicap
+  #serviceNameOverride: cicap
+  image: opencloudeu/clamav-icap:latest
+  port: 1344
+  resources: {}


### PR DESCRIPTION
Adds a `cicap` component to the dev-backends chart so the Kubernetes dev
install of docs gets a working ICAP antivirus server out of the box:

- c-icap server (openDesk `clamav-icap:0.6.4` image) + clamd sidecar
  (`clamav/clamav:stable`), emptyDir shared DB volume with init
  permission fix, configmap-hash rollout annotation
- ConfigMap with 4 configs: c-icap.conf (port 1344, logs to stdout),
  virus_scan.conf (avscan alias, MaxObjectSize 100M), clamd_mod.conf
  (127.0.0.1:3310), clamd.conf (StreamMaxLength 100M)
- values: registry/repository/tag, clamd image, maxObjectSize,
  streamMaxLength, resources
- chart version 0.0.9

Consumed by docs' kubernetes install guide: an ICAP service at
`cicap-dev-backend-cicap:1344` / service `avscan`.

Note: this repo's CI publishes the chart to gh-pages on push to main,
so merging this PR publishes 0.0.9 automatically.

See also PR suitenumerique/django-lasuite#80